### PR TITLE
Add Script Commands: Spotify Now Playing Song URL to Clipboard

### DIFF
--- a/media/spotify-now-playing-url.applescript
+++ b/media/spotify-now-playing-url.applescript
@@ -6,7 +6,7 @@
 # @raycast.mode silent
 
 # Optional parameters:
-# @raycast.icon https://www.iconfinder.com/data/icons/popular-services-brands/512/spotify-512.png
+# @raycast.icon images/spotify-logo.png
 
 # Documentation:
 # @raycast.author Jack LaFond


### PR DESCRIPTION
(Per @unnamedd's suggestions, I re-opened the PR from #52 with the correct icon once #51 is merged.)

This script copies the now playing song on Spotify as a URL.